### PR TITLE
[spectacle] Use ConfigParser instead of SafeConfigParser

### DIFF
--- a/spectacle/specify.py
+++ b/spectacle/specify.py
@@ -231,14 +231,14 @@ PATHMACROS = (('/usr/bin',     '%{_bindir}'),
 
 # Function to read config file to parser
 def read_config_file(configfile,config_parser = None):
-    from configparser import SafeConfigParser
+    from configparser import ConfigParser
     configfile = os.path.expanduser(configfile)
 
     if not os.path.exists(configfile):
         return None
     
     if not config_parser:
-        config_parser = SafeConfigParser()
+        config_parser = ConfigParser()
     
     config_parser.read(configfile)
     


### PR DESCRIPTION
SafeConfigParser was renamed to ConfigParser in Python 3.2, SafeConfigParser name was kept for compatibility,
Python 3.12 removes it:

https://docs.python.org/3/whatsnew/3.11.html#standard-library